### PR TITLE
updated Me.Metadata version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1
+- MicroElements.Metadata updated to 7.4.3
+
 # 2.0.0
 - MicroElements.Metadata updated to 7.0.0
 - MicroElements.Data updated to 2.0.0

--- a/src/MicroElements.Processing/MicroElements.Processing.csproj
+++ b/src/MicroElements.Processing/MicroElements.Processing.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="MicroElements.Functional" Version="1.10.0" />
     <PackageReference Include="MicroElements.Data" Version="2.0.0" />
-    <PackageReference Include="MicroElements.Metadata" Version="7.0.0" />
+    <PackageReference Include="MicroElements.Metadata" Version="7.4.3" />
     <PackageReference Include="NodaTime" Version="3.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0" />

--- a/test/MicroElements.Processing.Tests/SimpleTests.cs
+++ b/test/MicroElements.Processing.Tests/SimpleTests.cs
@@ -21,7 +21,7 @@ namespace MicroElements.Processing.Tests
         [Fact]
         public void property_set_should_be_not_null()
         {
-            SessionMetricsMeta.PropertySet.Should().NotContainNulls();
+            SessionMetricsMeta.PropertySet.GetProperties().Should().NotContainNulls();
             SessionMetricsMeta.GetProperties().Should().NotContainNulls();
         }
     }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Похоже, что из-за разных версий Me.Metadata возникает ошибка 
"Method not found: 'System.__Canon MicroElements.Metadata.SearchExtensions.GetValue(MicroElements.Metadata.IPropertyContainer, MicroElements.Metadata.IProperty`1<System.__Canon>, System.Nullable`1<MicroElements.Metadata.SearchOptions>)'"